### PR TITLE
parseDateTime: keep local timezone by default

### DIFF
--- a/lib/metadata/TableSchema.js
+++ b/lib/metadata/TableSchema.js
@@ -124,11 +124,11 @@ class TableSchema {
     }
 
     if (column.datatype.base.value === this.ns.dateTime.value) {
-      return this.factory.literal(parseDateTime(value, column.datatype.format, this.timezone), this.ns.dateTime)
+      return this.factory.literal(parseDateTime(value, column.datatype.format, this.timezone).toISO(), this.ns.dateTime)
     }
 
     if (column.datatype.base.value === this.ns.date.value) {
-      return this.factory.literal(parseDateTime(value, column.datatype.format, this.timezone).slice(0, 10), this.ns.date)
+      return this.factory.literal(parseDateTime(value, column.datatype.format, this.timezone).toFormat('yyyy-MM-dd'), this.ns.date)
     }
 
     if (column.datatype.base) {

--- a/lib/parseDateTime.js
+++ b/lib/parseDateTime.js
@@ -2,11 +2,11 @@ const { DateTime } = require('luxon')
 
 function parseDateTime (value, format, timezone) {
   if (format) {
-    return DateTime.fromFormat(value, format, { zone: timezone }).toUTC().toISO()
+    return DateTime.fromFormat(value, format, { zone: timezone })
   }
 
-  return DateTime.fromISO(value, { zone: timezone }).toUTC().toISO() ||
-    DateTime.fromRFC2822(value, { zone: timezone }).toUTC().toISO()
+  return DateTime.fromISO(value, { zone: timezone }) ||
+    DateTime.fromRFC2822(value, { zone: timezone })
 }
 
 module.exports = parseDateTime

--- a/test/parseDateTime.js
+++ b/test/parseDateTime.js
@@ -8,27 +8,21 @@ describe('parseDateTime', () => {
     assert.strictEqual(typeof parseDateTime, 'function')
   })
 
-  it('should return a string', () => {
-    const dateTime = parseDateTime('2018-01-01T00:00:00Z')
-
-    assert.strictEqual(typeof dateTime, 'string')
-  })
-
   it('should parse a date time string', () => {
     const dateTime = parseDateTime('2018-01-01T01:00:00.000+0100')
 
-    assert.strictEqual(dateTime, '2018-01-01T00:00:00.000Z')
+    assert.strictEqual(dateTime.toUTC().toISO(), '2018-01-01T00:00:00.000Z')
   })
 
   it('should parse a date time string and set the given timezone', () => {
     const dateTime = parseDateTime('2018-01-01T01:00:00', null, 'Europe/Berlin')
 
-    assert.strictEqual(dateTime, '2018-01-01T00:00:00.000Z')
+    assert.strictEqual(dateTime.toUTC().toISO(), '2018-01-01T00:00:00.000Z')
   })
 
   it('should parse a date time string using the format argument', () => {
     const dateTime = parseDateTime('20180101 000000', 'yyyyMMdd HHmmss', 'UTC')
 
-    assert.strictEqual(dateTime, '2018-01-01T00:00:00.000Z')
+    assert.strictEqual(dateTime.toUTC().toISO(), '2018-01-01T00:00:00.000Z')
   })
 })


### PR DESCRIPTION
Here's a solution to #14 .

Note that `parseDateTime()` doesn't return a string anymore. This makes it possible to properly display the date that was parsed.

Returning a string would require re-parsing the output of `parseDateTime()` in order to display in another timezone or in another format than ISO, which will sometimes be necessary. (See for instance how it is needed here: https://github.com/rdf-ext/rdf-parser-csvw/blob/de6da70bd72e5a20b49ef9c7eeb5915a514e3770/lib/metadata/TableSchema.js#L131 )