### PR TITLE
fix: use skip_records_with_error option and expand CsvParser tests

### DIFF
--- a/lib/CsvParser.js
+++ b/lib/CsvParser.js
@@ -17,7 +17,7 @@ class CsvParser extends Transform {
       record_delimiter: lineTerminators || [],
       relax_column_count: relaxColumnCount,
       rtrim: trim === 'end' || trim === 'true',
-      skip_lines_with_error: skipLinesWithError
+      skip_records_with_error: skipLinesWithError
     })
 
     this.parser.on('error', err => {

--- a/test/CsvParser.test.js
+++ b/test/CsvParser.test.js
@@ -87,6 +87,21 @@ describe('csvParser', () => {
     deepStrictEqual(output, expected)
   })
 
+  it('should handle errors', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ delimiter: ';' })
+
+    input.pipe(parser)
+    input.write('kzy1,key2\n')
+    input.write('value1_1;value2_1\n')
+    input.write('value1_2,value2_2\n')
+    input.end()
+
+    await rejects(async () => {
+      await chunks(parser)
+    })
+  })
+
   it('should parse lines with alternative delimiter', async () => {
     const input = new PassThrough()
     const parser = new CsvParser({ delimiter: ';' })
@@ -144,18 +159,187 @@ describe('csvParser', () => {
     deepStrictEqual(output, expected)
   })
 
-  it('should handle errors', async () => {
+  it('should use a custom quote character', async () => {
     const input = new PassThrough()
-    const parser = new CsvParser({ delimiter: ';' })
+    const parser = new CsvParser({ quoteChar: "'" })
 
     input.pipe(parser)
-    input.write('kzy1,key2\n')
-    input.write('value1_1;value2_1\n')
-    input.write('value1_2,value2_2\n')
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'val,ue0',
+        key1: 'value1'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
+    })
+
+    input.write('key0,key1\n')
+    input.write("'val,ue0','value1'\n")
     input.end()
 
-    await rejects(async () => {
-      await chunks(parser)
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
+  })
+
+  it('should parse CSV with relaxed column count', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ relaxColumnCount: true })
+
+    input.pipe(parser)
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'value0',
+        key1: 'value1'
+      }
+    }, {
+      line: 3,
+      row: {
+        key0: 'value2',
+        key1: 'value3',
+        key2: 'value4'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
     })
+
+    input.write('key0,key1,key2\n')
+    input.write('value0,value1\n')
+    input.write('value2,value3,value4\n')
+    input.end()
+
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
+  })
+
+  it('should skip lines with errors when skipLinesWithError is set', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ delimiter: ';', skipLinesWithError: true })
+
+    input.pipe(parser)
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'value0',
+        key1: 'value1'
+      }
+    }, {
+      line: 4,
+      row: {
+        key0: 'value2',
+        key1: 'value3'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
+    })
+
+    input.write('key0;key1\n')
+    input.write('value0;value1\n')
+    input.write('error_line\n')
+    input.write('value2;value3\n')
+    input.end()
+
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
+  })
+
+  it('should trim leading whitespace when trim is "start"', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ trim: 'start' })
+
+    input.pipe(parser)
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'value0',
+        key1: 'value1'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
+    })
+
+    input.write('key0,key1\n')
+    input.write('  value0,  value1\n')
+    input.end()
+
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
+  })
+
+  it('should trim trailing whitespace when trim is "end"', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ trim: 'end' })
+
+    input.pipe(parser)
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'value0',
+        key1: 'value1'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
+    })
+
+    input.write('key0,key1\n')
+    input.write('value0  ,value1  \n')
+    input.end()
+
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
+  })
+
+  it('should trim leading and trailing whitespace when trim is "true"', async () => {
+    const input = new PassThrough()
+    const parser = new CsvParser({ trim: 'true' })
+
+    input.pipe(parser)
+
+    const output = []
+    const expected = [{
+      line: 2,
+      row: {
+        key0: 'value0',
+        key1: 'value1'
+      }
+    }]
+
+    parser.on('data', data => {
+      output.push(data)
+    })
+
+    input.write('key0,key1\n')
+    input.write('  value0  ,  value1  \n')
+    input.end()
+
+    await chunks(parser)
+
+    deepStrictEqual(output, expected)
   })
 })


### PR DESCRIPTION
## Summary

- Fix `CsvParser` to use `skip_records_with_error` instead of the deprecated `skip_lines_with_error` option (renamed in csv-parse v7)
- Add missing test cases for `quoteChar`, `relaxColumnCount`, `skipLinesWithError`, and all three `trim` modes (`start`, `end`, `true`)
- Move the error-handling test to appear before the delimiter test for better organisation